### PR TITLE
Develop-add-branch-option

### DIFF
--- a/src/openfido
+++ b/src/openfido
@@ -84,7 +84,7 @@ except:
         quiet = False # print fewer messages as work is done
         orgname = "openfido" # default repo for workflows and pipelines
         branch = "main" # default branch to use when downloading workflows and pipelines
-        cache = "/usr/local/share/gridlabd/openfido" # additional path for downloaded modules
+        cache = "/usr/local/share/openfido" # additional path for downloaded modules
         apiurl = "https://api.github.com"
         rawurl = "https://raw.githubusercontent.com"
         giturl = "https://github.com"
@@ -110,7 +110,7 @@ def main(*args):
     """gridlabd-openfido main function"""
     execname = args[0]
     n = 1
-    while len(args) > n and args[n][0] == '-':
+    while len(args) > n and (args[n][0] == '-' or "=" in args[n]):
         if args[n] in ['-v','--verbose']:
             config.verbose = True
         elif args[n] in ['-q','--quiet']:
@@ -118,10 +118,17 @@ def main(*args):
         elif args[n] in ['--version']:
             poutput(openfido.__version__)
             sys.exit(0)
+        elif "=" in args[n]:
+            item = args[n].split('=')[0]
+            value = args[n].split('=')[1]
+            exec(f"config.{item} = '{value}'")
         else:
             perror(f"command option '{args[n]}' is not valid")
         n += 1
-    if len(args) > n:
+    if '-h' in args or '--help' in args:
+        command = "help"
+        options = []
+    elif len(args) > n:
         command = args[n]
         if len(sys.argv) > n+1:
             options = list(args[n+1:])
@@ -133,7 +140,7 @@ def main(*args):
     if hasattr(openfido,command):
         try:
             call = getattr(openfido,command)
-            result = call(options=options,stream=config.streams)
+            result = call(options=options,config=config,stream=config.streams)
             pverbose(result)
         except Exception as err:
             if hasattr(config,"traceback_file"):

--- a/src/openfido.py
+++ b/src/openfido.py
@@ -288,7 +288,6 @@ def install(options=[], config=[], stream=default_streams):
 	dryrun = os.system
 	failed = []
 	done = []
-	print("install options: ", options)
 	for option in options:
 		if option[0] == '-':
 			if option in ['-d','--dry-run']:
@@ -329,7 +328,7 @@ def install(options=[], config=[], stream=default_streams):
 					repo = Repository(target)
 					existing_branch = repo.head.name.split("/")[-1]
 					if branch == existing_branch:
-						stream["warning"](f"'{name}' is already installed in branch '{existing_branch}'")
+						pass
 					else:
 						stream["warning"](f"'{name}' is already installed in branch '{existing_branch}'. Repo branch will be switched to '{branch}'")
 						remove([name],config,stream)
@@ -451,7 +450,6 @@ def run(options=[], config=[], stream=command_streams):
 	cache = config.cache
 	branch = config.branch
 	path = f"{cache}/{name}"
-	print("path: ", path)
 	if not os.path.exists(f"{path}/openfido.json"):
 		raise Exception(f"'{cache}/{name}' not found")
 	if not install([name],config,stream)["ok"]:
@@ -482,7 +480,8 @@ def run(options=[], config=[], stream=command_streams):
 		inputs = ["/dev/stdin"]
 	if not outputs:
 		outputs = ["/dev/stdout"]
-	print("run flags: ", flags)
+	# inputs will be the name of input file
+	# outputs will be the name of output files
 	return module.main(inputs=inputs,outputs=outputs,options=flags)
 
 #

--- a/src/openfido.py
+++ b/src/openfido.py
@@ -245,7 +245,6 @@ def info(options=[], config=[], stream=default_streams):
 	name = options[0]
 	cache = config.cache
 	path = f"{cache}/{name}/__init__.py"
-	print("path: ", path)
 	if os.path.exists(path):
 		stream["verbose"](f"examining {path}")
 		spec = importlib.util.spec_from_file_location(name,path)

--- a/src/openfido.py
+++ b/src/openfido.py
@@ -443,7 +443,6 @@ def run(options=[], config=[], stream=command_streams):
 
 	The `run` function runs an openfido product on the local system.
 	"""
-	print(55555)
 	if not options:
 		raise Exception("missing package name")
 	name = options[0]
@@ -478,7 +477,6 @@ def run(options=[], config=[], stream=command_streams):
 		inputs = ["/dev/stdin"]
 	if not outputs:
 		outputs = ["/dev/stdout"]
-	print(66666)
 	return module.main(inputs=inputs,outputs=outputs,options=flags)
 
 #

--- a/src/openfido.py
+++ b/src/openfido.py
@@ -443,6 +443,7 @@ def run(options=[], config=[], stream=command_streams):
 
 	The `run` function runs an openfido product on the local system.
 	"""
+	print(55555)
 	if not options:
 		raise Exception("missing package name")
 	name = options[0]
@@ -477,6 +478,7 @@ def run(options=[], config=[], stream=command_streams):
 		inputs = ["/dev/stdin"]
 	if not outputs:
 		outputs = ["/dev/stdout"]
+	print(66666)
 	return module.main(inputs=inputs,outputs=outputs,options=flags)
 
 #

--- a/src/openfido.py
+++ b/src/openfido.py
@@ -450,9 +450,7 @@ def run(options=[], config=[], stream=command_streams):
 	cache = config.cache
 	branch = config.branch
 	path = f"{cache}/{name}"
-	if not os.path.exists(f"{path}/openfido.json"):
-		raise Exception(f"'{cache}/{name}' not found")
-	if not install([name],config,stream)["ok"]:
+	if not install([name],config,stream)["ok"] and not os.path.exists(f"{path}/openfido.json"):
 		raise Exception(f"unable to install '{name}' in branch '{branch}' into openfido cache '{cache}'")
 	sys.path.append(f"{cache}/{name}")
 	if not os.path.exists(f"{path}/__init__.py"):
@@ -480,8 +478,6 @@ def run(options=[], config=[], stream=command_streams):
 		inputs = ["/dev/stdin"]
 	if not outputs:
 		outputs = ["/dev/stdout"]
-	# inputs will be the name of input file
-	# outputs will be the name of output files
 	return module.main(inputs=inputs,outputs=outputs,options=flags)
 
 #


### PR DESCRIPTION
This PR addresses the integration of branches selection.
# Code changes

- [x] Add support for setting up `config` variable to enable passing `{item}={value}` to import options from users or callers.
- [x] Add default settings for `config` variable.

# Documentation changes
None

# Test and Validation Notes

1.  Example test code

- openfido run cyme-extract IEEE13.mdb IEEE13.glm
- openfido branch=develop run cyme-extract IEEE13.mdb IEEE13.glm