### PR TITLE
Develop add docker backup restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,5 +131,5 @@ src/openfido.err
 .DS_Store
 .pipelines.csv
 
-# docker images back file
-*.tar
+# docker images backup file
+backup/

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 src/openfido.err
 .DS_Store
 .pipelines.csv
+
+# docker images back file
+*.tar

--- a/README.md
+++ b/README.md
@@ -62,11 +62,6 @@ If the options are not provided, the default value of the options are:
 * If an image name `BACKUPIMAGENAME:[TAG]`.tar is provided, then the named image is restored. The image should be located under `./backup` folder.
 * If a server is active, then the restore command will fail, unless the `--force` option is provided.
 
-### Commit
-
-* Commit a current image by `docker commit openfido-server-1 [IMAGENAME[:TAG]] | pv` command.
-* If server is not active, run commit image by `openfido server [--imagename IMAGENAME[:TAG]] start` command
-
 # Developers
 
 See the `dev` folder for details on developer tools.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The command `openfido` supports the following subcommands:
 * `openfido [OPTIONS] run PRODUCT [OPTIONS] inputlist outputlist`
 * `openfido [OPTIONS] update PRODUCT ...`
 * `openfido [OPTIONS] server [--imagename IMAGENAME[:TAG]] [start|stop|restart|status|update|open]`
-* `openfido [OPTIONS] server [backup] [BACKUPIMAGENAME[:TAG]]`
-* `openfido [OPTIONS] server [--imagename IMAGENAME[:TAG]] [restore] [--force]`
+* `openfido [OPTIONS] server [--backupname BACKUPIMAGENAME] [backup]`
+* `openfido [OPTIONS] server [--backupname BACKUPIMAGENAME] [restore] [--force]`
 * `openfido [OPTIONS] pipeline [create|start|delete|list] [ARGUMENTS]`
 * `openfido [OPTIONS] workflow [create|start|delete|list] [ARGUMENTS]`
 * `openfido [OPTIONS] validate PRODUCT`
@@ -40,26 +40,32 @@ The following general options are available
 * `-h|--help`      get basic help
 * `-q|--quiet`     disable unnecessary output
 * `-v|--verbose`   enable extra output
-* `--version`      print the version number 
+* `--version`      print the version number
 
-The default value of the options:
+If the options are not provided, the default value of the options are:
 
 * `IMAGENAME[:TAG] = openfido/openfido:latest`
-* `BACKUPIMAGENAME:[TAG] = openfido-[YYMMDD-HHMMSS]:backup`
+* `BACKUPIMAGENAME = openfido-backup-latest`
 
 ### Backup
 
 * The `opentifo server backup` command will commit an image based on the current state of the container (default container name is `openfido-server-1`).
-* The default name of the image is `openfido-backup-YYMMDD-HHMMSS`.
-* The most recently saved image is named as `openfido-backup-latest` under `./backup` folder.
-* Once the tar file is saved, any older images is removed to save space including commit image `openfido-backup-YYMMDD-HHMMSS`.
+* The default name of the commited image is `openfido-backup-YYMMDD-HHMMSS:backup`.
+* The most recently saved image is named is `openfido-backup-latest` under `./backup` folder.
+* Once the tar file is saved, any older images is removed.
 * The most recently saved image should be kept until a newer one is committed.
-  
+
 ### Restore
 
-* The `opentifo server restore` command will restore the most recently saved image.
-* If an image name `BACKUPIMAGENAME:[TAG]` is provided, then the named image is restored.
-* If a server is active, then the restore command should fail, unless the `--force` option is provided.
+* To restore the commited image under docker images list. Please stop the current server first and use `opentifo server --imagename [IMAGENAME[:TAG]] start` command.
+* To load and restore image from .tar file. Please use `opentifo server restore` command to load and restore the most recently saved image from `openfido-backup-latest.tar` under `./backup` folder.
+* If an image name `BACKUPIMAGENAME:[TAG]`.tar is provided, then the named image is restored. The image should be located under `./backup` folder.
+* If a server is active, then the restore command will fail, unless the `--force` option is provided.
+
+### Commit
+
+* Commit a current image by `docker commit openfido-server-1 [IMAGENAME[:TAG]] | pv` command.
+* If server is not active, run commit image by `openfido server [--imagename IMAGENAME[:TAG]] start` command
 
 # Developers
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The command `openfido` supports the following subcommands:
 * `openfido [OPTIONS] run PRODUCT [OPTIONS] inputlist outputlist`
 * `openfido [OPTIONS] update PRODUCT ...`
 * `openfido [OPTIONS] server [--imagename IMAGENAME[:TAG]] [start|stop|restart|status|update|open]`
+* `openfido [OPTIONS] server [backup] [BACKUPIMAGENAME[:TAG]]`
+* `openfido [OPTIONS] server [--imagename IMAGENAME[:TAG]] [restore] [--force]`
 * `openfido [OPTIONS] pipeline [create|start|delete|list] [ARGUMENTS]`
 * `openfido [OPTIONS] workflow [create|start|delete|list] [ARGUMENTS]`
 * `openfido [OPTIONS] validate PRODUCT`
@@ -39,6 +41,25 @@ The following general options are available
 * `-q|--quiet`     disable unnecessary output
 * `-v|--verbose`   enable extra output
 * `--version`      print the version number 
+
+The default value of the options:
+
+* `IMAGENAME[:TAG] = openfido/openfido:latest`
+* `BACKUPIMAGENAME:[TAG] = openfido-[YYMMDD-HHMMSS]:backup`
+
+### Backup
+
+* The `opentifo server backup` command will commit an image based on the current state of the container (default container name is `openfido-server-1`).
+* The default name of the image is `openfido-backup-YYMMDD-HHMMSS`.
+* The most recently saved image is named as `openfido-backup-latest` under `./backup` folder.
+* Once the tar file is saved, any older images is removed to save space including commit image `openfido-backup-YYMMDD-HHMMSS`.
+* The most recently saved image should be kept until a newer one is committed.
+  
+### Restore
+
+* The `opentifo server restore` command will restore the most recently saved image.
+* If an image name `BACKUPIMAGENAME:[TAG]` is provided, then the named image is restored.
+* If a server is active, then the restore command should fail, unless the `--force` option is provided.
 
 # Developers
 

--- a/src/openfido-server
+++ b/src/openfido-server
@@ -5,10 +5,10 @@ LOGFILE="/var/log/openfido.log"
 touch $LOGFILE 1>/dev/null 2>&1|| LOGFILE="openfido.log"
 
 HOSTNAME="127.0.0.1"
-IMAGENAME="openfido/openfido:latest"
-
+IMAGENAME=${IMAGENAME:-openfido/openfido:latest}
+BACKUPIMAGENAME=${BACKUPIMAGENAME:-openfido-backup-latest}
+FORCERESTORE=${FORCERESTORE:-false}
 PORTNUM="3000"
-
 OPTIONS=""
 
 if [ -f "$0.conf" ]; then
@@ -64,9 +64,14 @@ function status ()
 
 function start ()
 {
-	echo "****************************************************************************************************"
-	echo "OPTIONS: $OPTIONS, HOSTNAME: $HOSTNAME, PORTNUM:$ $PORTNUM, IMAGENAME:$IMAGENAME,  LOGFILE:$LOGFILE"
-	echo "****************************************************************************************************"
+	echo "*********************"
+	echo "OPTIONS: $OPTIONS, "
+	echo "HOSTNAME: $HOSTNAME," 
+	echo "PORTNUM:$ $PORTNUM," 
+	echo "IMAGENAME:$IMAGENAME,"  
+	echo "LOGFILE:$LOGFILE"
+	echo "*********************"
+
 	if [ "$(status)" == "STOPPED" ]; then
 		echo -n "Starting openfido server"
 		docker rm openfido-server-1 1>/dev/null 2>/dev/null || true
@@ -104,41 +109,57 @@ function stop ()
 
 function backup()
 {
-	# commit image
+	# check previous commited image exits
+	if [ ! -z "$(docker images -q  openfido-backup-"*")" ]; then 
+		# remove previous commit image
+		echo "remove previous commited image"
+		for image_id in $(docker images -q  openfido-backup-"*")
+		do
+			docker rmi $image_id
+		done
+		
+	fi
+
+	# commit current image
 	currentTime=$(date '+%Y%m%d-%H%M%S')
-	echo "commit docker image:openfido-$currentTime:backup"
-	docker commit openfido-server-1 openfido-$currentTime:backup | pv 
-	# save image to .gzip
-	echo "save docker image:openfido-$currentTime:backup to  openfido-backup-latest.tar"
+	echo "commit docker image:openfido-backup-$currentTime:backup"
+	docker commit openfido-server-1 openfido-backup-$currentTime:backup | pv 
+	# # save image to .tar
+	echo "save docker image:openfido-backup-$currentTime:backup to $BACKUPIMAGENAME.tar"
 	if [ ! -d backup ]; then 
 		mkdir backup
 		chmod +rw backup
 	fi
-	docker save openfido-$currentTime:backup | pv -s $(docker image inspect openfido-$currentTime:backup --format='{{.Size}}') | gzip > ./backup/openfido-backup-latest.gzip
-	# remove commit image
-	docker rmi openfido-$currentTime:backup 
+	docker save openfido-backup-$currentTime:backup | pv -s $(docker image inspect openfido-backup-$currentTime:backup --format='{{.Size}}') > ./backup/$BACKUPIMAGENAME.tar
 
 }
 
 function restore()
 {	
+	# check if backup image exist 
+	if [ ! -f ./backup/$BACKUPIMAGENAME.tar ]; then 
+		error 1 "$BACKUPIMAGENAME.tar: no such file "
+	fi
+	# check if server not active and --force is not true 
 	PID=$(docker container ls -q -f name=openfido-server-1)
 	if [ ! -z "$PID" ]; then
 		# if server is active 
-		error 1 "openfido-server-1 is activated, please stop server and re-run restore command!! "
+		if [ $FORCERESTORE == "true" ]; then 
+			# stop server
+			echo "force to stop server"
+			stop
+		else
+			error 1 "openfido-server-1 is activated, please stop server or use [--force] options to force restore!!!"
+		fi
 	fi
-	# check if backup image exist 
-	if [ ! -f ./backup/openfido-backup-latest.gzip ]; then 
-		error 1 "openfido-backup-latest.tar: no such file "
-	fi
-	# load image
-	echo "load back up docker image: openfido-backup-latest.gzip "
-	response=$(pv ./backup/openfido-backup-latest.gzip | docker load)
-	IMAGENAME=${response##*Loaded image: } # get the string after "Loaded image: "
-	echo "load back up to docker-image:$IMAGENAME"
-	# check current image 
 
-	echo "run backup image:$IMAGENAME"
+	# load image
+	echo "load back up docker image: $BACKUPIMAGENAME.tar "
+	response=$(pv ./backup/$BACKUPIMAGENAME.tar | docker load)
+	IMAGENAME=${response##*Loaded image: } # get the string after "Loaded image: "
+
+	echo "load back up to docker-image:$BACKUPIMAGENAME"
+	echo "run backup image:$BACKUPIMAGENAME"
 	start
 }
 
@@ -163,10 +184,23 @@ function _open()
 	open http://$HOSTNAME:$PORTNUM/	
 }
 
+
+
 if [ "$1" == "--imagename" ]; then
 	IMAGENAME=$2
+	# check if docker image is not default name:openfido/openfido:latest , then check if docker image exists locally. 
+	if [ $IMAGENAME != "openfido/openfido:latest" ]; then 
+		[ -n "$(docker images -q $IMAGENAME)" ] || error 1 "docker image:$IMAGENAME does not exist"
+	fi
 	shift 2
 fi
+
+if [ "$1" == "--backupname" ]; then
+	BACKUPIMAGENAME=$2
+	echo "BACKUPIMAGENAME=$BACKUPIMAGENAME"
+	shift 2
+fi
+
 if [ "$1" == "update" ]; then
 	update
 elif [ "$1" == "start" ]; then
@@ -179,11 +213,14 @@ elif [ "$1" == "restart" ]; then
 elif [ "$1" == "open" ]; then
 	_open
 elif [ "$1" == "backup" ]; then
+	backup
 	shift 1
-	backup $1
 elif [ "$1" == "restore" ]; then
-	shift 1
-	restore $1
+	if [ "$2" == "--force" ]; then 
+		FORCERESTORE="true"
+	fi
+	restore 
+	shift 2
 elif [ "$1" == "status" ]; then
 	STATUS=$(status)
 	case ${STATUS:-UNKNOWN} in

--- a/src/openfido-server
+++ b/src/openfido-server
@@ -108,9 +108,13 @@ function backup()
 	currentTime=$(date '+%Y%m%d-%H%M%S')
 	echo "commit docker image:openfido-$currentTime:backup"
 	docker commit openfido-server-1 openfido-$currentTime:backup | pv 
-	# save image to tar
+	# save image to .gzip
 	echo "save docker image:openfido-$currentTime:backup to  openfido-backup-latest.tar"
-	docker save openfido-$currentTime:backup | pv -s $(docker image inspect openfido-$currentTime:backup --format='{{.Size}}') | gzip > openfido-backup-latest.tar
+	if [ ! -d backup ]; then 
+		mkdir backup
+		chmod +rw backup
+	fi
+	docker save openfido-$currentTime:backup | pv -s $(docker image inspect openfido-$currentTime:backup --format='{{.Size}}') | gzip > ./backup/openfido-backup-latest.gzip
 	# remove commit image
 	docker rmi openfido-$currentTime:backup 
 
@@ -118,42 +122,24 @@ function backup()
 
 function restore()
 {	
+	PID=$(docker container ls -q -f name=openfido-server-1)
+	if [ ! -z "$PID" ]; then
+		# if server is active 
+		error 1 "openfido-server-1 is activated, please stop server and re-run restore command!! "
+	fi
 	# check if backup image exist 
-	if [ ! -f openfido-backup-latest.tar ]; then 
+	if [ ! -f ./backup/openfido-backup-latest.gzip ]; then 
 		error 1 "openfido-backup-latest.tar: no such file "
 	fi
 	# load image
-	echo "load back up docker image: openfido-backup-latest.tar "
-	response=$(pv openfido-backup-latest.tar | docker load)
-	imagename=${response##*Loaded image: }
-	echo "load back up to docker-image:$imagename"
-	# stop current image 
-	echo "stop current image "
-	echo "run back image:$imagename"
+	echo "load back up docker image: openfido-backup-latest.gzip "
+	response=$(pv ./backup/openfido-backup-latest.gzip | docker load)
+	IMAGENAME=${response##*Loaded image: } # get the string after "Loaded image: "
+	echo "load back up to docker-image:$IMAGENAME"
+	# check current image 
 
-	echo "****************************************************************************************************"
-	echo "OPTIONS: $OPTIONS, HOSTNAME: $HOSTNAME, PORTNUM:$ $PORTNUM, IMAGENAME:$imagename,  LOGFILE:$LOGFILE"
-	echo "****************************************************************************************************"
-	if [ "$(status)" == "STOPPED" ]; then
-		echo -n "Starting openfido server"
-		docker rm openfido-server-1 1>/dev/null 2>/dev/null || true
-		docker run --name openfido-server-1 $OPTIONS -v /tmp:/tmp -v /var/run/docker.sock:/var/run/docker.sock -p $HOSTNAME:5001:5001 -p $HOSTNAME:5002:5002 -p $HOSTNAME:5003:5003 -p $HOSTNAME:9000:9000 -p $HOSTNAME:3000:$PORTNUM ${imagename} 1>>$LOGFILE 2>&1 &
-		while [ "$(status)" == "STOPPED" ]; do
-			sleep 1
-		done
-		while [ "$(status)" == "NOREPLY" ]; do
-			echo -n "."
-			sleep 1
-		done
-		if [ "$(status)" != "OK" ]; then
-			echo "startup failed (status=$(status)), killing server"
-			PID=$(docker container ls -q -f name=openfido-server-1)
-			docker container kill $PID > /dev/null
-		fi
-		echo "ok"
-	else
-		error 1 "unabled to start, server status is $(status)"
-	fi
+	echo "run backup image:$IMAGENAME"
+	start
 }
 
 function stop ()

--- a/src/openfido-server
+++ b/src/openfido-server
@@ -64,6 +64,9 @@ function status ()
 
 function start ()
 {
+	echo "****************************************************************************************************"
+	echo "OPTIONS: $OPTIONS, HOSTNAME: $HOSTNAME, PORTNUM:$ $PORTNUM, IMAGENAME:$IMAGENAME,  LOGFILE:$LOGFILE"
+	echo "****************************************************************************************************"
 	if [ "$(status)" == "STOPPED" ]; then
 		echo -n "Starting openfido server"
 		docker rm openfido-server-1 1>/dev/null 2>/dev/null || true
@@ -101,12 +104,70 @@ function stop ()
 
 function backup()
 {
-	error 1 "backup not implemented yet"
+	# commit image
+	currentTime=$(date '+%Y%m%d-%H%M%S')
+	echo "commit docker image:openfido-$currentTime:backup"
+	docker commit openfido-server-1 openfido-$currentTime:backup | pv 
+	# save image to tar
+	echo "save docker image:openfido-$currentTime:backup to  openfido-backup-latest.tar"
+	docker save openfido-$currentTime:backup | pv -s $(docker image inspect openfido-$currentTime:backup --format='{{.Size}}') | gzip > openfido-backup-latest.tar
+	# remove commit image
+	docker rmi openfido-$currentTime:backup 
+
 }
 
 function restore()
+{	
+	# check if backup image exist 
+	if [ ! -f openfido-backup-latest.tar ]; then 
+		error 1 "openfido-backup-latest.tar: no such file "
+	fi
+	# load image
+	echo "load back up docker image: openfido-backup-latest.tar "
+	response=$(pv openfido-backup-latest.tar | docker load)
+	imagename=${response##*Loaded image: }
+	echo "load back up to docker-image:$imagename"
+	# stop current image 
+	echo "stop current image "
+	echo "run back image:$imagename"
+
+	echo "****************************************************************************************************"
+	echo "OPTIONS: $OPTIONS, HOSTNAME: $HOSTNAME, PORTNUM:$ $PORTNUM, IMAGENAME:$imagename,  LOGFILE:$LOGFILE"
+	echo "****************************************************************************************************"
+	if [ "$(status)" == "STOPPED" ]; then
+		echo -n "Starting openfido server"
+		docker rm openfido-server-1 1>/dev/null 2>/dev/null || true
+		docker run --name openfido-server-1 $OPTIONS -v /tmp:/tmp -v /var/run/docker.sock:/var/run/docker.sock -p $HOSTNAME:5001:5001 -p $HOSTNAME:5002:5002 -p $HOSTNAME:5003:5003 -p $HOSTNAME:9000:9000 -p $HOSTNAME:3000:$PORTNUM ${imagename} 1>>$LOGFILE 2>&1 &
+		while [ "$(status)" == "STOPPED" ]; do
+			sleep 1
+		done
+		while [ "$(status)" == "NOREPLY" ]; do
+			echo -n "."
+			sleep 1
+		done
+		if [ "$(status)" != "OK" ]; then
+			echo "startup failed (status=$(status)), killing server"
+			PID=$(docker container ls -q -f name=openfido-server-1)
+			docker container kill $PID > /dev/null
+		fi
+		echo "ok"
+	else
+		error 1 "unabled to start, server status is $(status)"
+	fi
+}
+
+function stop ()
 {
-	error 1 "restore not implemented yet"
+	PID=$(docker container ls -q -f name=openfido-server-1)
+	if [ -z "$PID" ]; then
+		warning "no server active"
+	else
+		echo -n "Stopping openfido server..."
+		docker container kill $PID > /dev/null
+		docker container rm $PID > /dev/null
+		echo "ok"
+	fi
+
 }
 
 function _open()

--- a/src/openfido.py
+++ b/src/openfido.py
@@ -468,12 +468,17 @@ def server(options=[], stream=command_streams):
 
 	The `server` function controls the local openfido server running on docker.
 	"""
+	print("options: ", options[0], options[1])
 	if len(options) == 0:
 		raise Exception("missing server command")
-	elif len(options) > 1:
-		raise Exception("too many server commands")
-	else:
+	elif len(options) == 1:
 		subprocess.run(["/usr/local/bin/openfido-server",options[0]])
+	elif len(options) == 2:
+		subprocess.run(["/usr/local/bin/openfido-server",options[0],options[1]])
+	else:
+		raise Exception("too many server commands")
+
+		
 
 #
 # PIPELINE FUNCTION

--- a/src/openfido.py
+++ b/src/openfido.py
@@ -468,13 +468,14 @@ def server(options=[], stream=command_streams):
 
 	The `server` function controls the local openfido server running on docker.
 	"""
-	print("options: ", options[0], options[1])
 	if len(options) == 0:
 		raise Exception("missing server command")
 	elif len(options) == 1:
 		subprocess.run(["/usr/local/bin/openfido-server",options[0]])
 	elif len(options) == 2:
 		subprocess.run(["/usr/local/bin/openfido-server",options[0],options[1]])
+	elif len(options) == 3:
+		subprocess.run(["/usr/local/bin/openfido-server",options[0],options[1],options[2]])
 	else:
 		raise Exception("too many server commands")
 


### PR DESCRIPTION
This PR
1). adds #10 `openfido server start | restore` feature. 
2). fixed #11  issue. The 'openfido server [--imagename  [IMAGENAME:[TAG]]] [start|....]` command is working.

# Current issues
None installation requirements features. 

# Code changes
1). `openfido-server` file
2). `openfido.py` file


# Documentation changes

* `openfido [OPTIONS] server [--imagename IMAGENAME[:TAG]] [start|stop|restart|status|update|open]`
* `openfido [OPTIONS] server [--backupname BACKUPIMAGENAME] [backup]`
* `openfido [OPTIONS] server [--backupname BACKUPIMAGENAME] [restore] [--force]`

If the options are not provided, the default value of the options are:

* `IMAGENAME[:TAG] = openfido/openfido:latest`
* `BACKUPIMAGENAME = openfido-backup-latest`

### Backup

* The `opentifo server backup` command will commit an image based on the current state of the container (default container name is `openfido-server-1`).
* The default name of the commited image is `openfido-backup-YYMMDD-HHMMSS:backup`.
* The most recently saved image is named is `openfido-backup-latest` under `./backup` folder.
* Once the tar file is saved, any older images is removed.
* The most recently saved image should be kept until a newer one is committed.

### Restore

* To restore the commited image under docker images list. Please stop the current server first and use `opentifo server --imagename [IMAGENAME[:TAG]] start` command.
* To load and restore image from .tar file. Please use `opentifo server restore` command to load and restore the most recently saved image from `openfido-backup-latest.tar` under `./backup` folder.
* If an image name `BACKUPIMAGENAME:[TAG]`.tar is provided, then the named image is restored. The image should be located under `./backup` folder.
* If a server is active, then the restore command will fail, unless the `--force` option is provided.
