### PR TITLE
Fix missing credentials after restore image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,48 @@
 # OpenFIDO Command Line Interface (CLI)
 
+## Installation
+
 To install the OpenFIDO CLI, enter the following command at the command prompt:
 
+### Setup environment
+
+If `cmake` had been installed in your system, run:
+
 ~~~
-curl -sL https://raw.githubusercontent.com/openfido/cli/main/install.sh | bash
+make setup
+~~~
+
+or you can use shell command with options:
+
+~~~
+sudo ./setup.sh [-v|--info|-h|-f]
+~~~
+
+#### Setup options
+
+* `-h|--help            Print this helpful output`
+* `--info               Print information about this install`
+* `-v|--verbose         Run showing log output`
+* `-s|--silent          Run without showing commands`
+* `-f|--force           Force install into existing target folder`
+
+#### support platfrom
+
+* Mac OSX: Monterey
+* Ubuntu: 22.04
+* Debian: 11
+* CentOS: 8
+* Amazon EC2
+  * In Amazon EC2, Please run `sudo export PATH=/usr/local/bin:$PATH` first before run `make setup` command.
+
+### Install CLI
+
+This program needs to run inside the `docker`. Please make sure you have `docker server` installed and run in your system. For docker installation, please check `https://docs.docker.com/get-docker/` for detail.
+
+Install the `opnenfido cli` , run command:
+
+~~~
+make install
 ~~~
 
 If you wish to install from an alternate repo or branch, e.g., `develop`, use the command:
@@ -14,7 +53,7 @@ export OPENFIDO_BRANCH=develop
 curl -sL https://raw.githubusercontent.com/${OPENFIDO_PROJECT}/${OPENFIDO_BRANCH}/install.sh | bash
 ~~~
 
-# Quick Start
+## Quick Start
 
 The command `openfido` supports the following subcommands:
 
@@ -33,7 +72,7 @@ The command `openfido` supports the following subcommands:
 * `openfido [OPTIONS] workflow [create|start|delete|list] [ARGUMENTS]`
 * `openfido [OPTIONS] validate PRODUCT`
 
-## Options
+#### Options
 
 The following general options are available
 
@@ -47,22 +86,20 @@ If the options are not provided, the default value of the options are:
 * `IMAGENAME[:TAG] = openfido/openfido:latest`
 * `BACKUPIMAGENAME = openfido-backup-latest`
 
-### Backup
+#### Backup
 
 * The `opentifo server backup` command will commit an image based on the current state of the container (default container name is `openfido-server-1`).
-* The default name of the commited image is `openfido-backup-YYMMDD-HHMMSS:backup`.
 * The most recently saved image is named is `openfido-backup-latest` under `./backup` folder.
 * Once the tar file is saved, any older images is removed.
-* The most recently saved image should be kept until a newer one is committed.
 
-### Restore
+#### Restore
 
 * To restore the commited image under docker images list. Please stop the current server first and use `opentifo server --imagename [IMAGENAME[:TAG]] start` command.
 * To load and restore image from .tar file. Please use `opentifo server restore` command to load and restore the most recently saved image from `openfido-backup-latest.tar` under `./backup` folder.
 * If an image name `BACKUPIMAGENAME:[TAG]`.tar is provided, then the named image is restored. The image should be located under `./backup` folder.
 * If a server is active, then the restore command will fail, unless the `--force` option is provided.
 
-# Developers
+## Developers
 
 See the `dev` folder for details on developer tools.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ To install the OpenFIDO CLI, enter the following command at the command prompt:
 curl -sL https://raw.githubusercontent.com/openfido/cli/main/install.sh | bash
 ~~~
 
+If you wish to install from an alternate repo or branch, e.g., `develop`, use the command:
+
+~~~
+
+export OPENFIDO_PROJECT=openfido/cli
+export OPENFIDO_BRANCH=develop
+curl -sL https://raw.githubusercontent.com/${OPENFIDO_PROJECT}/${OPENFIDO_BRANCH}/install.sh | bash
+~~~
+
+
 ## Quick Start
 
 The command `openfido` supports the following subcommands:

--- a/README.md
+++ b/README.md
@@ -4,53 +4,8 @@
 
 To install the OpenFIDO CLI, enter the following command at the command prompt:
 
-### Setup environment
-
-If `cmake` had been installed in your system, run:
-
 ~~~
-make setup
-~~~
-
-or you can use shell command with options:
-
-~~~
-sudo ./setup.sh [-v|--info|-h|-f]
-~~~
-
-#### Setup options
-
-* `-h|--help            Print this helpful output`
-* `--info               Print information about this install`
-* `-v|--verbose         Run showing log output`
-* `-s|--silent          Run without showing commands`
-* `-f|--force           Force install into existing target folder`
-
-#### support platfrom
-
-* Mac OSX: Monterey
-* Ubuntu: 22.04
-* Debian: 11
-* CentOS: 8
-* Amazon EC2
-  * In Amazon EC2, Please run `sudo export PATH=/usr/local/bin:$PATH` first before run `make setup` command.
-
-### Install CLI
-
-This program needs to run inside the `docker`. Please make sure you have `docker server` installed and run in your system. For docker installation, please check `https://docs.docker.com/get-docker/` for detail.
-
-Install the `opnenfido cli` , run command:
-
-~~~
-make install
-~~~
-
-If you wish to install from an alternate repo or branch, e.g., `develop`, use the command:
-
-~~~
-export OPENFIDO_PROJECT=openfido/cli
-export OPENFIDO_BRANCH=develop
-curl -sL https://raw.githubusercontent.com/${OPENFIDO_PROJECT}/${OPENFIDO_BRANCH}/install.sh | bash
+curl -sL https://raw.githubusercontent.com/openfido/cli/main/install.sh | bash
 ~~~
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ If the options are not provided, the default value of the options are:
 
 * The `opentifo server backup` command will commit an image based on the current state of the container (default container name is `openfido-server-1`).
 * The most recently saved image is named is `openfido-backup-latest` under `./backup` folder.
-* Once the tar file is saved, any older images is removed.
+* Once the tar file is saved, any older images are removed.
 
 #### Restore
 
-* To restore the commited image under docker images list. Please stop the current server first and use `opentifo server --imagename [IMAGENAME[:TAG]] start` command.
+* To restore the saved image under docker images list. Please stop the current server first and use `opentifo server --imagename [IMAGENAME[:TAG]] start` command.
 * To load and restore image from .tar file. Please use `opentifo server restore` command to load and restore the most recently saved image from `openfido-backup-latest.tar` under `./backup` folder.
 * If an image name `BACKUPIMAGENAME:[TAG]`.tar is provided, then the named image is restored. The image should be located under `./backup` folder.
 * If a server is active, then the restore command will fail, unless the `--force` option is provided.

--- a/src/openfido-server
+++ b/src/openfido-server
@@ -109,28 +109,38 @@ function stop ()
 
 function backup()
 {
-	# check previous commited image exits
-	if [ ! -z "$(docker images -q  openfido-backup-"*")" ]; then 
-		# remove previous commit image
-		echo "remove previous commited image"
-		for image_id in $(docker images -q  openfido-backup-"*")
-		do
-			docker rmi $image_id
-		done
-		
+	# checkk if openfido/openfido image is activate. 
+	PID=$(docker container ls -q -f name=openfido-server-1)
+	if [ -z "$PID" ]; then
+		error 1 "no server active, please activate server then run the backup command"
 	fi
 
-	# commit current image
 	currentTime=$(date '+%Y%m%d-%H%M%S')
-	echo "commit docker image:openfido-backup-$currentTime:backup"
-	docker commit openfido-server-1 openfido-backup-$currentTime:backup | pv 
+	docker save openfido/openfido:latest | pv -s $(docker image inspect openfido/openfido:latest --format='{{.Size}}') > ./backup/$BACKUPIMAGENAME.tar
+	# commit current image -> 
+	# ****************************************************************************************************
+	# To do the commit feature require to export .env file first to save credentials. 
+	# To get original credentials in loading image, please import the .env file run openfido server --imagename [NAME] start
+	# ****************************************************************************************************
+	# check previous commited image exits
+	# if [ ! -z "$(docker images -q  openfido-backup-"*")" ]; then 
+	# 	# remove previous commit image
+	# 	echo "remove previous commited image"
+	# 	for image_id in $(docker images -q  openfido-backup-"*")
+	# 	do
+	# 		docker rmi $image_id
+	# 	done
+		
+	# fi
+	# echo "commit docker image:openfido-backup-$currentTime:backup"
+	# docker commit openfido-server-1 openfido-backup-$currentTime:backup | pv 
 	# # save image to .tar
-	echo "save docker image:openfido-backup-$currentTime:backup to $BACKUPIMAGENAME.tar"
-	if [ ! -d backup ]; then 
-		mkdir backup
-		chmod +rw backup
-	fi
-	docker save openfido-backup-$currentTime:backup | pv -s $(docker image inspect openfido-backup-$currentTime:backup --format='{{.Size}}') > ./backup/$BACKUPIMAGENAME.tar
+	# echo "save docker image:openfido-backup-$currentTime:backup to $BACKUPIMAGENAME.tar"
+	# if [ ! -d backup ]; then 
+	# 	mkdir backup
+	# 	chmod +rw backup
+	# fi
+	# docker save openfido-backup-$currentTime:backup | pv -s $(docker image inspect openfido-backup-$currentTime:backup --format='{{.Size}}') > ./backup/$BACKUPIMAGENAME.tar
 
 }
 

--- a/src/openfido-server
+++ b/src/openfido-server
@@ -29,6 +29,13 @@ function warning()
 {
 	echo "WARNING [openfido-server]: $*"
 }
+
+# check for commands that absolutely necessary to proceed
+function require()
+{
+	$1 ${2:---version} > /dev/null 2>&1 || error 1 "$1 is required"
+}
+
 function update ()
 {
 	echo -n "Checking for updates..."
@@ -110,6 +117,7 @@ function stop ()
 function backup()
 {
 	# checkk if openfido/openfido image is activate. 
+	require pv
 	PID=$(docker container ls -q -f name=openfido-server-1)
 	if [ -z "$PID" ]; then
 		error 1 "no server active, please activate server then run the backup command"
@@ -146,6 +154,7 @@ function backup()
 
 function restore()
 {	
+	require pv
 	# check if backup image exist 
 	if [ ! -f ./backup/$BACKUPIMAGENAME.tar ]; then 
 		error 1 "$BACKUPIMAGENAME.tar: no such file "


### PR DESCRIPTION
This PR fixed #16. 
The `openfido server backup` commits the image first then saves the image later. The commit command didn't keep all the `.env` files where credentials save. It causes missing credentials after restoring the image. 

# Code Change
- [x]  openfido-server file. Save images directly without committing images first. 
~~~
currentTime=$(date '+%Y%m%d-%H%M%S')
docker save openfido/openfido:latest | pv -s $(docker image inspect openfido/openfido:latest --format='{{.Size}}') > ./backup/$BACKUPIMAGENAME.tar
~~~
# Documents Change

#### Backup

* The `opentifo server backup` command will commit an image based on the current state of the container (default container name is `openfido-server-1`).
* The most recently saved image is named is `openfido-backup-latest` under `./backup` folder.
* Once the tar file is saved, any older images are removed.