### PR TITLE
transfer openfido/openfido:latest to openfido/cli:latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ The command `openfido` supports the following subcommands:
 * `openfido [OPTIONS] run PRODUCT [OPTIONS] inputlist outputlist`
 * `openfido [OPTIONS] update PRODUCT ...`
 * `openfido [OPTIONS] server [--imagename IMAGENAME[:TAG]] [start|stop|restart|status|update|open]`
-* `openfido [OPTIONS] server [--backupname BACKUPIMAGENAME] [backup]`
-* `openfido [OPTIONS] server [--backupname BACKUPIMAGENAME] [restore] [--force]`
 * `openfido [OPTIONS] pipeline [create|start|delete|list] [ARGUMENTS]`
 * `openfido [OPTIONS] workflow [create|start|delete|list] [ARGUMENTS]`
 * `openfido [OPTIONS] validate PRODUCT`
@@ -48,21 +46,8 @@ The following general options are available
 
 If the options are not provided, the default value of the options are:
 
-* `IMAGENAME[:TAG] = openfido/openfido:latest`
-* `BACKUPIMAGENAME = openfido-backup-latest`
+* `IMAGENAME[:TAG] = openfido/cli:latest`
 
-#### Backup
-
-* The `opentifo server backup` command will commit an image based on the current state of the container (default container name is `openfido-server-1`).
-* The most recently saved image is named is `openfido-backup-latest` under `./backup` folder.
-* Once the tar file is saved, any older images are removed.
-
-#### Restore
-
-* To restore the saved image under docker images list. Please stop the current server first and use `opentifo server --imagename [IMAGENAME[:TAG]] start` command.
-* To load and restore image from .tar file. Please use `opentifo server restore` command to load and restore the most recently saved image from `openfido-backup-latest.tar` under `./backup` folder.
-* If an image name `BACKUPIMAGENAME:[TAG]`.tar is provided, then the named image is restored. The image should be located under `./backup` folder.
-* If a server is active, then the restore command will fail, unless the `--force` option is provided.
 
 ## Developers
 

--- a/src/openfido-server
+++ b/src/openfido-server
@@ -5,7 +5,7 @@ LOGFILE="/var/log/openfido.log"
 touch $LOGFILE 1>/dev/null 2>&1|| LOGFILE="openfido.log"
 
 HOSTNAME="127.0.0.1"
-IMAGENAME=${IMAGENAME:-openfido/openfido:latest}
+IMAGENAME=${IMAGENAME:-openfido/cli:latest}
 BACKUPIMAGENAME=${BACKUPIMAGENAME:-openfido-backup-latest}
 FORCERESTORE=${FORCERESTORE:-false}
 PORTNUM="3000"
@@ -116,7 +116,7 @@ function stop ()
 
 function backup()
 {
-	# checkk if openfido/openfido image is activate. 
+	# checkk if openfido/cli image is activate. 
 	require pv
 	PID=$(docker container ls -q -f name=openfido-server-1)
 	if [ -z "$PID" ]; then
@@ -124,7 +124,7 @@ function backup()
 	fi
 
 	currentTime=$(date '+%Y%m%d-%H%M%S')
-	docker save openfido/openfido:latest | pv -s $(docker image inspect openfido/openfido:latest --format='{{.Size}}') > ./backup/$BACKUPIMAGENAME.tar
+	docker save openfido/cli:latest | pv -s $(docker image inspect openfido/cli:latest --format='{{.Size}}') > ./backup/$BACKUPIMAGENAME.tar
 	# commit current image -> 
 	# ****************************************************************************************************
 	# To do the commit feature require to export .env file first to save credentials. 
@@ -207,8 +207,8 @@ function _open()
 
 if [ "$1" == "--imagename" ]; then
 	IMAGENAME=$2
-	# check if docker image is not default name:openfido/openfido:latest , then check if docker image exists locally. 
-	if [ $IMAGENAME != "openfido/openfido:latest" ]; then 
+	# check if docker image is not default name:openfido/cli:latest , then check if docker image exists locally. 
+	if [ $IMAGENAME != "openfido/cli:latest" ]; then 
 		[ -n "$(docker images -q $IMAGENAME)" ] || error 1 "docker image:$IMAGENAME does not exist"
 	fi
 	shift 2

--- a/src/openfido.py
+++ b/src/openfido.py
@@ -87,7 +87,7 @@ def config(options=[], stream=default_streams):
 	The `config` function manages the openfido configuration file.  There are three possible locations
 	for the file `openfido_config.py`, and they are used in the following order of precedence:
 		1. `./openfido_config.py`
-		2. `$HOME/.openfido/openfido_config.py`
+		2. `$HOME/.openfido/cli.py`
 		3. `/usr/local/share/openfido_config.py`
 	"""
 	if len(options) == 0:


### PR DESCRIPTION
1. Update the docker image from openfido/openfido:latest to openfido/cli:latest
2. Remove backup and restore function from README.md. (currently broken)